### PR TITLE
Update gatsby local search to also include headers

### DIFF
--- a/config/search.js
+++ b/config/search.js
@@ -16,19 +16,40 @@ const searchPluginConfig = {
             fields {
               path
             }
+            tableOfContents
           }
         }
       }
     `,
     index: ["title"],
     normalizer: ({ data }) =>
-      data.allMdx.nodes.map((node) => ({
-        id: node.id,
-        title: node.frontmatter.title,
-        description: node.frontmatter.description,
-        url: node.fields.path,
-        isExternal: false,
-      })),
+      data.allMdx.nodes.flatMap((node) => {
+        // return at least the main page ("node")
+        const returnVal = [
+          {
+            id: node.id,
+            title: node.frontmatter.title,
+            description: node.frontmatter.description,
+            url: node.fields.path,
+            isExternal: false,
+            toc: node.tableOfContents,
+          },
+        ];
+
+        // add the headers  too if they're in ToC
+        if (node.tableOfContents.items != null) {
+          node.tableOfContents.items.map((header) =>
+            returnVal.push({
+              id: node.id.concat(header.url),
+              title: node.frontmatter.title.concat(" - ", header.title),
+              url: node.fields.path.concat(header.url),
+              isExternal: false,
+            })
+          );
+        }
+
+        return returnVal;
+      }),
   },
 };
 


### PR DESCRIPTION
This fixes https://github.com/delta-io/delta-docs/issues/27

If we want this to be better we should use an external plugin like the existing docs instead of reinventing the wheel. In either case we can continue to improve this if needed.

<img width="966" alt="image" src="https://user-images.githubusercontent.com/1390267/219513757-a23d88ae-37c8-4458-a14a-022886a8de83.png">
