### PR TITLE
Fixing search result visibility on desktop

### DIFF
--- a/src/components/PageLayout/PageHeaderSearchInput.jsx
+++ b/src/components/PageLayout/PageHeaderSearchInput.jsx
@@ -140,6 +140,9 @@ const PageHeaderSearchInput = (props) => {
                   href={result.url}
                   key={result.id}
                   newTab={result.isExternal}
+                  onClick={() => {
+                    onChange("");
+                  }}
                 >
                   <em>{result.type}</em>
                   <strong>


### PR DESCRIPTION
This small change emulates the same pattern elsewhere (setting input to empty string)

For some reason this doens't work on mobile view, but at least for desktop this is enough.