### PR TITLE
Pinning versions for the quickstart docker image for Delta Lake Core v2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .cache/
 public
+.DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@
 /coverage
 /package-lock.json
 *.mdx
+00000000000000000000.json

--- a/static/quickstart_docker/Dockerfile_delta_quickstart
+++ b/static/quickstart_docker/Dockerfile_delta_quickstart
@@ -1,17 +1,20 @@
-ARG BASE_CONTAINER=yikunkero/spark:latest
+# This docker image uses a base container with Apache Spark v3.3.1
+ARG BASE_CONTAINER=yikunkero/spark:3.3.1-scala2.12-java11-python3-r-ubuntu
 
 FROM $BASE_CONTAINER as spark
 
-LABEL maintainer="Andrew Bauman"
+LABEL maintainer="Prashanth Babu"
 
 FROM spark as delta
 
 USER root
 
+# Docker image was created and tested with Delta Lake v2.1.0
 ARG DELTA_CORE_VERSION="2.1.0"
 
-RUN pip install --no-cache-dir delta-spark==${DELTA_CORE_VERSION} \
-jupyterlab deltalake pandas roapi
+# We are explicitly pinning the versions of various libraries which this Docker image runs on
+RUN pip install --quiet --no-cache-dir delta-spark==${DELTA_CORE_VERSION} \
+deltalake==0.6.4 jupyterlab==3.5.1 pandas==1.5.2 roapi==0.8.1
 
 FROM delta as startup
 
@@ -21,8 +24,8 @@ ARG WORKDIR=/opt/spark/work-dir
 ENV DELTA_PACKAGE_VERSION=delta-core_2.12:2.1.0
 
 RUN groupadd -r ${GROUP} && useradd -r -m -g ${GROUP} ${NBuser}
-RUN apt-get update
-RUN apt-get -y install vim
+RUN apt-get -qq update
+RUN apt-get -qq -y install vim
 
 COPY --chown=${NBuser} startup.sh "${WORKDIR}"
 COPY --chown=${NBuser} quickstart.ipynb "${WORKDIR}"

--- a/static/quickstart_docker/Dockerfile_delta_quickstart
+++ b/static/quickstart_docker/Dockerfile_delta_quickstart
@@ -1,3 +1,5 @@
+### Dockerfile for Delta Lake quickstart
+
 # This docker image uses a base container with Apache Spark v3.3.1
 ARG BASE_CONTAINER=yikunkero/spark:3.3.1-scala2.12-java11-python3-r-ubuntu
 
@@ -9,14 +11,15 @@ FROM spark as delta
 
 USER root
 
-# Docker image was created and tested with the following versions of Delta Lake
+# Docker image was created and tested with the versions of following packages.
+# Note: Python version in this image is 3.8.10 and is available as `python3`.
 ARG DELTA_SPARK_VERSION="2.1.0"
 ARG DELTALAKE_VERSION="0.6.4"
 ARG JUPYTERLAB_VERSION="3.5.1"
 ARG PANDAS_VERSION="1.5.2"
 ARG ROAPI_VERSION="0.8.1"
 
-# We are explicitly pinning the versions of various libraries which this Docker image runs on
+# We are explicitly pinning the versions of various libraries which this Docker image runs on.
 RUN pip install --quiet --no-cache-dir delta-spark==${DELTA_SPARK_VERSION} \
 deltalake==${DELTALAKE_VERSION} jupyterlab==${JUPYTERLAB_VERSION} pandas==${PANDAS_VERSION} roapi==${ROAPI_VERSION}
 

--- a/static/quickstart_docker/README.md
+++ b/static/quickstart_docker/README.md
@@ -1,6 +1,8 @@
-# What is this?
+# README for Delta Lake quickstart_docker
 
-This folder contains instructions and materials to get new users started with Delta Lake and work through the quickstart materials. Follow the steps below to build an Apache Spark image with Delta Lake intalled, run a container, and follow the quickstart in an interactive notebook or shell.
+This folder contains instructions and materials to get new users started with Delta Lake and work through the quickstart materials. 
+
+Follow the steps below to build an Apache Spark<sup>TM</sup> image with Delta Lake installed, run a container, and follow the quickstart in an interactive notebook or shell with any of the options like Python, PySpark, Scala Spark or even Rust.
 
 1. [Build the image](#Build-the-Image)
 2. [Choose an interface](#Choose-an-Interface)
@@ -10,11 +12,11 @@ This folder contains instructions and materials to get new users started with De
 1. Clone this repo
 2. Navigate to the cloned folder
 3. Navigate to the quickstart_docker folder
-4. open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
+4. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 5. Execute the following from the `static/quickstart_docker` folder
 
    ```bash
-   docker build -t delta_quickstart -f Dockerfile_quickstart .
+   docker build -t delta_quickstart -f Dockerfile_delta_quickstart .
    ```
 
 Once the image has been built, you can then move on to running the quickstart in a notebook or shell.
@@ -27,10 +29,10 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
 
 ## Choose an Interface
 - [delta-rs Python](#delta-rs-python)
-- [Juypter Lab Notebook](#jupyter-lab-notebook)
+- [JupyterLab Notebook](#jupyterlab-notebook)
 - [PySpark Shell](#pyspark-shell)
 - [Scala Shell](#scala-shell)
-- [Rust API](#delta-rust-api)
+- [Delta Rust API](#delta-rust-api)
 - [ROAPI](#optional-roapi)
 
 
@@ -40,7 +42,7 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
 2. Run a container from the built image with a bash entrypoint
 
    ```bash
-   docker run --rm -it --entrypoint bash delta_quickstart
+   docker run --name delta_quickstart --rm -it --entrypoint bash delta_quickstart
    ```
 
 3. Launch a _python_ interactive shell session
@@ -49,7 +51,7 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
    python3
    ```
 
-   > Note, the Delta Rust Python bindings is already installed in this docker. To do this manually in your own environment, you can install `pip3 install deltalake`
+   > Note, the Delta Rust Python bindings are already installed in this docker. To do this manually in your own environment, you can install `pip3 install deltalake`
 
 4. Run some basic commands in the shell
 
@@ -78,12 +80,13 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
 <details>
   <summary>Click to view output</summary>
 
-   ```bash
-   dt.to_pandas() 
+   ```python
+   dt.to_pandas()
 
    ## Output
        0
    0   0
+   1   1
    ... ...
    8   9
    9  10
@@ -97,20 +100,18 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
   ```python
   # List files for the Delta table
   dt.files()
-  ```
-  ```python
+
   ## Output
-  ['0-0ba7c7af-28bd-4125-84a4-acab9898b2dc-0.parquet', '1-00e32c3a-d7ec-484f-a347-29d9f54c1a6c-0.parquet']
+  ['0-c949fc59-61c8-4dc4-b114-f3c05c4277a2-0.parquet', '1-eb49e2d3-77c3-4a70-8b58-674ccf40faae-0.parquet']
   ```
 
   4.2. Review history
   ```python
   # Review history
   dt.history()
-  ```
-  ```python  
+   
   ## Output
-  [{'delta-rs': '0.5.0', 'timestamp': 1670708720583}, {'clientVersion': 'delta-rs.0.5.0', 'operation': 'delta-rs.Write', 'operationParameters': {'mode': 'Append', 'partitionBy': [], 'predicate': None}, 'timestamp': 1670708731359}]
+  [{'delta-rs': '0.5.0', 'timestamp': 1681364905661}, {'clientVersion': 'delta-rs.0.5.0', 'operation': 'delta-rs.Write', 'operationParameters': {'mode': 'Append', 'partitionBy': [], 'predicate': None}, 'timestamp': 1681364905671}]
   ```
 
   4.3. Time Travel (load older version of table)
@@ -134,34 +135,33 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
 
 5. Follow the delta-rs Python documentation [here](https://delta-io.github.io/delta-rs/python/usage.html#)
 
-6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in /tmp/deltars-table. Once you close your pyspark process, run a list command in your Docker shell and you should get something similar to below.
+6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in /tmp/deltars-table. Once you close your python3 process, run a list command in your Docker shell and you should get something similar to below.
 
 <details><summary>Click to view output</summary>
 
 ```bash
 $ ls -lsgA /tmp/deltars_table
 total 12
-4 -rw-r--r-- 1 NBuser 1610 Dec 10 21:45 0-0ba7c7af-28bd-4125-84a4-acab9898b2dc-0.parquet
-4 -rw-r--r-- 1 NBuser 1612 Dec 10 21:45 1-00e32c3a-d7ec-484f-a347-29d9f54c1a6c-0.parquet
-4 drwxr-xr-x 2 NBuser 4096 Dec 10 21:45 _delta_log   
+4 -rw-r--r-- 1 NBuser 1610 Apr 13 05:48 0-c949fc59-61c8-4dc4-b114-f3c05c4277a2-0.parquet
+4 -rw-r--r-- 1 NBuser 1612 Apr 13 05:48 1-eb49e2d3-77c3-4a70-8b58-674ccf40faae-0.parquet
+4 drwxr-xr-x 2 NBuser 4096 Apr 13 05:48 _delta_log
 ```
 </details>
 
 7. [Optional] Skip ahead to try out the [Delta Rust API](#delta-rust-api) and [ROAPI](#optional-roapi)
 
-### Jupyter Lab Notebook
+### JupyterLab Notebook
 
 1. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 2. Run a container from the built image with a Juypter Lab entrypoint
 
    ```bash
-   docker run --rm -it -p 8888-8889:8888-8889 delta_quickstart
+   docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 delta_quickstart
    ```
 
-3. Follow or cut/paste the Jupyter Lab
-4. Open the quickstart notebook and follow along
+3. Follow along the JupyterLab notebook URL the above command lists.
 
-**Note that you may also use launch the pyspark or scala shells after launching a terminal in Jupyter Lab**
+**Note that you may also use launch the pyspark or scala shells after launching a terminal in JupyterLab**
 
 ### Pyspark Shell
 
@@ -169,7 +169,7 @@ total 12
 2. Run a container from the built image with a bash entrypoint
 
    ```bash
-   docker run --rm -it --entrypoint bash delta_quickstart
+   docker run --name delta_quickstart --rm -it --entrypoint bash delta_quickstart
    ```
 
 3. Launch a pyspark interactive shell session
@@ -187,10 +187,19 @@ total 12
    data = spark.range(0, 5)
 
    # Write Delta table
-   data.write.format("delta").save("/tmp/delta-table")
+   (data
+      .write
+      .format("delta")
+      .save("/tmp/delta-table")
+   )
 
    # Read Delta table
-   df = spark.read.format("delta").load("/tmp/delta-table")
+   df = (spark
+           .read
+           .format("delta")
+           .load("/tmp/delta-table")
+           .orderBy("id")
+         )
 
    # Show Delta table
    df.show()
@@ -205,15 +214,15 @@ total 12
 ```bash
 $ ls -lsgA /tmp/delta-table
 total 36
-4 drwxr-xr-x 2 NBuser 4096 Oct 18 02:02 _delta_log
-4 -rw-r--r-- 1 NBuser  478 Oct 18 02:02 part-00000-b968d89a-b299-401f-a6db-ba0c160633ab-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00000-b968d89a-b299-401f-a6db-ba0c160633ab-c000.snappy.parquet.crc
-4 -rw-r--r-- 1 NBuser  478 Oct 18 02:02 part-00001-f0f8ea27-b522-4c2c-8fe3-7224fccacb91-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00001-f0f8ea27-b522-4c2c-8fe3-7224fccacb91-c000.snappy.parquet.crc
-4 -rw-r--r-- 1 NBuser  478 Oct 18 02:02 part-00002-b8a1ea0d-0637-4432-8ab6-8ec864edb6b0-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00002-b8a1ea0d-0637-4432-8ab6-8ec864edb6b0-c000.snappy.parquet.crc
-4 -rw-r--r-- 1 NBuser  486 Oct 18 02:02 part-00003-ba20f466-8cb6-4827-9c10-218e8933f0f7-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00003-ba20f466-8cb6-4827-9c10-218e8933f0f7-c000.snappy.parquet.crc
+4 drwxr-xr-x 2 NBuser 4096 Apr 13 06:01 _delta_log
+4 -rw-r--r-- 1 NBuser  478 Apr 13 06:01 part-00000-56a2c68a-f90e-4764-8bf7-a29a21a04230-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:01 .part-00000-56a2c68a-f90e-4764-8bf7-a29a21a04230-c000.snappy.parquet.crc
+4 -rw-r--r-- 1 NBuser  478 Apr 13 06:01 part-00001-bcbb45ab-6317-4229-a6e6-80889ee6b957-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:01 .part-00001-bcbb45ab-6317-4229-a6e6-80889ee6b957-c000.snappy.parquet.crc
+4 -rw-r--r-- 1 NBuser  478 Apr 13 06:01 part-00002-9e0efb76-a0c9-45cf-90d6-0dba912b3c2f-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:01 .part-00002-9e0efb76-a0c9-45cf-90d6-0dba912b3c2f-c000.snappy.parquet.crc
+4 -rw-r--r-- 1 NBuser  486 Apr 13 06:01 part-00003-909fee02-574a-47ba-9a3b-d531eec7f0d7-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:01 .part-00003-909fee02-574a-47ba-9a3b-d531eec7f0d7-c000.snappy.parquet.crc
 ```
 </details>
 
@@ -223,7 +232,7 @@ total 36
 2. Run a container from the built image with a bash entrypoint
 
    ```bash
-   docker run --rm -it --entrypoint bash delta_quickstart
+   docker run --name delta_quickstart --rm -it --entrypoint bash delta_quickstart
    ```
 
 3. Launch a scala interactive shell session
@@ -237,15 +246,23 @@ total 36
 4. Run some basic commands in the shell
 
    ```scala
-
    // Create Spark DataFrame
    val data = spark.range(0, 5)
 
    // Write Delta table
-   data.write.format("delta").save("/tmp/delta-table")
+   (data
+      .write
+      .format("delta")
+      .save("/tmp/delta-table")
+   )
 
    // Read Delta table
-   val df = spark.read.format("delta").load("/tmp/delta-table")
+   val df = (spark
+               .read
+               .format("delta")
+               .load("/tmp/delta-table")
+               .orderBy("id")
+            )
 
    // Show Delta table
    df.show()
@@ -261,15 +278,15 @@ total 36
 ```bash
 $ ls -lsgA /tmp/delta-table
 total 36
-4 drwxr-xr-x 2 NBuser 4096 Oct 18 02:02 _delta_log
-4 -rw-r--r-- 1 NBuser  478 Oct 18 02:02 part-00000-b968d89a-b299-401f-a6db-ba0c160633ab-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00000-b968d89a-b299-401f-a6db-ba0c160633ab-c000.snappy.parquet.crc
-4 -rw-r--r-- 1 NBuser  478 Oct 18 02:02 part-00001-f0f8ea27-b522-4c2c-8fe3-7224fccacb91-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00001-f0f8ea27-b522-4c2c-8fe3-7224fccacb91-c000.snappy.parquet.crc
-4 -rw-r--r-- 1 NBuser  478 Oct 18 02:02 part-00002-b8a1ea0d-0637-4432-8ab6-8ec864edb6b0-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00002-b8a1ea0d-0637-4432-8ab6-8ec864edb6b0-c000.snappy.parquet.crc
-4 -rw-r--r-- 1 NBuser  486 Oct 18 02:02 part-00003-ba20f466-8cb6-4827-9c10-218e8933f0f7-c000.snappy.parquet
-4 -rw-r--r-- 1 NBuser   12 Oct 18 02:02 .part-00003-ba20f466-8cb6-4827-9c10-218e8933f0f7-c000.snappy.parquet.crc
+4 drwxr-xr-x 2 NBuser 4096 Apr 13 06:04 _delta_log
+4 -rw-r--r-- 1 NBuser  478 Apr 13 06:04 part-00000-5cb4c21e-5297-4ec2-8f90-51a77a157baf-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:04 .part-00000-5cb4c21e-5297-4ec2-8f90-51a77a157baf-c000.snappy.parquet.crc
+4 -rw-r--r-- 1 NBuser  478 Apr 13 06:04 part-00001-3802402e-0846-40ce-87c5-ba50836cf873-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:04 .part-00001-3802402e-0846-40ce-87c5-ba50836cf873-c000.snappy.parquet.crc
+4 -rw-r--r-- 1 NBuser  478 Apr 13 06:04 part-00002-e5082dfc-ba87-4027-8e06-abddd281c65d-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:04 .part-00002-e5082dfc-ba87-4027-8e06-abddd281c65d-c000.snappy.parquet.crc
+4 -rw-r--r-- 1 NBuser  486 Apr 13 06:04 part-00003-5655406d-cc0b-41bb-80ed-b1dec3117bad-c000.snappy.parquet
+4 -rw-r--r-- 1 NBuser   12 Apr 13 06:04 .part-00003-5655406d-cc0b-41bb-80ed-b1dec3117bad-c000.snappy.parquet.crc
 ```
 </details>
 
@@ -279,7 +296,7 @@ total 36
 2. Run a container from the built image with a bash entrypoint
 
    ```bash
-   docker run --rm -it --entrypoint bash delta_quickstart
+   docker run --name delta_quickstart --rm -it --entrypoint bash delta_quickstart
    ```
 
 3. Execute `examples/read_delta_table.rs` to review the Delta table metadata and files of the `covid19_nyt` Delta table.
@@ -381,12 +398,12 @@ You can query your Delta Lake table with [Apache Arrow](https://github.com/apach
 2. Run a container from the built image with a bash entrypoint
 
    ```bash
-   docker run --rm -it -p 8080:8080 --entrypoint bash delta_quickstart
+   docker run --name delta_quickstart --rm -it -p 8080:8080 --entrypoint bash delta_quickstart
    ```
 3. Start the `roapi` API using the following command.  Notes: 
 
    + the API calls are pushed to the `nohup.out` file.
-   + if you haven't created the `deltars_table` in your container create it via the shell options above (python, pyspark, scala) or via the jupyter lab quickstart notebook.  Alternatively you may omit the following from the command:
+   + if you haven't created the `deltars_table` in your container create it via the [delta-rs Python](#delta-rs-python) option above.  Alternatively you may omit the following from the command:
    `--table 'deltars_table=/tmp/deltars_table/,format=delta'` as well as any steps that call the `deltars_table`
 
 
@@ -394,7 +411,12 @@ You can query your Delta Lake table with [Apache Arrow](https://github.com/apach
    nohup roapi --addr-http 0.0.0.0:8080 --table 'deltars_table=/tmp/deltars_table/,format=delta' --table 'covid19_nyt=/opt/spark/work-dir/rs/data/COVID-19_NYT,format=delta' &
    ```
 
-4. Open another shell and check the schema of the two Delta tables
+4. Open another shell to connect to the same Docker image.
+   ```bash
+   docker exec -it delta_quickstart /bin/bash
+   ```
+
+5. Check the schema of the two Delta tables
    ```bash
    curl localhost:8080/api/schema
    ```
@@ -423,28 +445,28 @@ curl localhost:8080/api/schema
 ```bash
 curl -X POST -d "SELECT * FROM deltars_table"  localhost:8080/api/sql
 
-[{"0":6},{"0":7},{"0":8},{"0":9},{"0":10},{"0":0},{"0":1},{"0":2},{"0":3},{"0":4}]
+[{"0":0},{"0":1},{"0":2},{"0":3},{"0":4},{"0":6},{"0":7},{"0":8},{"0":9},{"0":10}]
 ```
 </details>
 
 
 6. Query the `covid19_nyt` table
    ```bash
-   curl -X POST -d "SELECT cases, county, date FROM covid19_nyt LIMIT 5" localhost:8080/api/sql
+   curl -X POST -d "SELECT cases, county, date FROM covid19_nyt ORDER BY cases DESC LIMIT 5" localhost:8080/api/sql
    ```
 
 <details><summary>Click to view output</summary>
 
 ```bash
 
-curl -X POST -d "SELECT cases, county, date FROM covid19_nyt LIMIT 5" localhost:8080/api/sql
+curl -X POST -d "SELECT cases, county, date FROM covid19_nyt ORDER BY cases DESC LIMIT 5" localhost:8080/api/sql
 
 [
-   {"cases":987,"county":"San Benito","date":"2020-08-25"},
-   {"cases":45666,"county":"San Bernardino","date":"2020-08-25"},
-   {"cases":37057,"county":"San Diego","date":"2020-08-25"},
-   {"cases":8984,"county":"San Francisco","date":"2020-08-25"},
-   {"cases":16565,"county":"San Joaquin","date":"2020-08-25"}
+    {"cases":1208672,"county":"Los Angeles","date":"2021-03-11"},
+    {"cases":1207361,"county":"Los Angeles","date":"2021-03-10"},
+    {"cases":1205924,"county":"Los Angeles","date":"2021-03-09"},
+    {"cases":1204665,"county":"Los Angeles","date":"2021-03-08"},
+    {"cases":1203799,"county":"Los Angeles","date":"2021-03-07"}
 ]
 ```
 

--- a/static/quickstart_docker/README.md
+++ b/static/quickstart_docker/README.md
@@ -1,6 +1,8 @@
-# README for Delta Lake quickstart_docker
+# README for Delta Lake quickstart with Docker
 
-This folder contains instructions and materials to get new users started with Delta Lake and work through the quickstart materials. 
+This folder contains instructions and materials to get new users started with Delta Lake and work through the quickstart materials using a self-contained Docker image.
+
+> Note: The basic prerequisite for following along using Delta Lake Docker image is having Docker installed on your machine. Please follow the steps from the Docker website to install Docker locally. Based on your local machine operating system, please choose the appropriate option listed on the [Get Docker](https://docs.docker.com/get-docker/) page.
 
 Follow the steps below to build an Apache Spark<sup>TM</sup> image with Delta Lake installed, run a container, and follow the quickstart in an interactive notebook or shell with any of the options like Python, PySpark, Scala Spark or even Rust.
 
@@ -13,7 +15,7 @@ Follow the steps below to build an Apache Spark<sup>TM</sup> image with Delta La
 
 1. Clone this repo
 2. Navigate to the cloned folder
-3. Navigate to the quickstart_docker folder
+3. Navigate to the `quickstart_docker` folder
 4. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 5. Execute the following from the `static/quickstart_docker` folder
 
@@ -30,6 +32,7 @@ In the following instructions, the variable `${DELTA_PACKAGE_VERSION}` refers to
 The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark 3.3.1.
 
 ## Choose an Interface
+
 - [delta-rs Python](#delta-rs-python)
 - [JupyterLab Notebook](#jupyterlab-notebook)
 - [PySpark Shell](#pyspark-shell)
@@ -37,8 +40,8 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
 - [Delta Rust API](#delta-rust-api)
 - [ROAPI](#optional-roapi)
 
-
 ### delta-rs Python
+
 1. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 
 2. Run a container from the built image with a bash entrypoint
@@ -47,96 +50,102 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
    docker run --name delta_quickstart --rm -it --entrypoint bash delta_quickstart
    ```
 
-3. Launch a _python_ interactive shell session
+3. Launch a _python_ interactive shell session with `python3`
 
    ```bash
    python3
    ```
 
-   > Note: The Delta Rust Python bindings are already installed in this docker. To do this manually in your own environment, you can install `pip3 install deltalake==0.6.4`
+   > Note: The Delta Rust Python bindings are already installed in this docker. To do this manually in your own environment, run the command: `pip3 install deltalake==0.6.4`
 
-4. Run some basic commands in the shell
+4. Run some basic commands in the shell to write to and read from Delta Lake with Pandas
 
    ```python
    import pandas as pd
    from deltalake.writer import write_deltalake
    from deltalake import DeltaTable
 
-   # Create Pandas DataFrame
+   # Create a Pandas DataFrame
    df = pd.DataFrame(range(5))
 
-   # Write Delta Lake table
+   # Write to the Delta Lake table
    write_deltalake("/tmp/deltars_table", df)
 
    # Append new data
    df = pd.DataFrame(range(6, 11))
    write_deltalake("/tmp/deltars_table", df, mode="append")
 
-   # Read Delta Lake table
+   # Read the Delta Lake table
    dt = DeltaTable("/tmp/deltars_table")
 
-   # Show Delta table
+   # Show the Delta table
    dt.to_pandas()
    ```
 
 <details>
   <summary>Click to view output</summary>
 
-   ```python
-   dt.to_pandas()
+```python
+dt.to_pandas()
 
-   ## Output
-       0
-   0   0
-   1   1
-   ... ...
-   8   9
-   9  10
-   ```
+## Output
+    0
+0   0
+1   1
+2   2
+... ...
+8   9
+9  10
+```
+
 </details>
 
 <details>
   <summary><b>Click for more examples including files information and time travel</b></summary>
 
-  4.1. Review the files
-  ```python
-  # List files for the Delta table
-  dt.files()
+4.1. Review the files
 
-  ## Output
-  ['0-c949fc59-61c8-4dc4-b114-f3c05c4277a2-0.parquet', '1-eb49e2d3-77c3-4a70-8b58-674ccf40faae-0.parquet']
-  ```
+```python
+# List files for the Delta table
+dt.files()
 
-  4.2. Review history
-  ```python
-  # Review history
-  dt.history()
-   
-  ## Output
-  [{'delta-rs': '0.5.0', 'timestamp': 1681364905661}, {'clientVersion': 'delta-rs.0.5.0', 'operation': 'delta-rs.Write', 'operationParameters': {'mode': 'Append', 'partitionBy': [], 'predicate': None}, 'timestamp': 1681364905671}]
-  ```
+## Output
+['0-c949fc59-61c8-4dc4-b114-f3c05c4277a2-0.parquet', '1-eb49e2d3-77c3-4a70-8b58-674ccf40faae-0.parquet']
+```
 
-  4.3. Time Travel (load older version of table)
-  ```python
-  # Load initial version of table
-  dt.load_version(0)
+4.2. Review history
 
-  # Show table
-  dt.to_pandas()
+```python
+# Review history
+dt.history()
 
-  ## Output
-      0
-   0  0
-   1  1
-   2  2
-   3  3
-   4  4  
-   ```
+## Output
+[{'delta-rs': '0.5.0', 'timestamp': 1681364905661}, {'clientVersion': 'delta-rs.0.5.0', 'operation': 'delta-rs.Write', 'operationParameters': {'mode': 'Append', 'partitionBy': [], 'predicate': None}, 'timestamp': 1681364905671}]
+```
+
+4.3. Time Travel (load older version of table)
+
+```python
+# Load initial version of table
+dt.load_version(0)
+
+# Show table
+dt.to_pandas()
+
+## Output
+    0
+ 0  0
+ 1  1
+ 2  2
+ 3  3
+ 4  4
+```
+
 </details>
 
 5. Follow the delta-rs Python documentation [here](https://delta-io.github.io/delta-rs/python/usage.html#)
 
-6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in /tmp/deltars-table. Once you close your python3 process, run a list command in your Docker shell and you should get something similar to below.
+6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in `/tmp/deltars-table`. Once you close your `python3` process, run a list command in your Docker shell and you should get something similar to below.
 
 <details><summary>Click to view output</summary>
 
@@ -147,6 +156,7 @@ total 12
 4 -rw-r--r-- 1 NBuser 1612 Apr 13 05:48 1-eb49e2d3-77c3-4a70-8b58-674ccf40faae-0.parquet
 4 drwxr-xr-x 2 NBuser 4096 Apr 13 05:48 _delta_log
 ```
+
 </details>
 
 7. [Optional] Skip ahead to try out the [Delta Rust API](#delta-rust-api) and [ROAPI](#optional-roapi)
@@ -160,11 +170,11 @@ total 12
    docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 delta_quickstart
    ```
 
-3. Follow along the JupyterLab notebook URL the above command lists.
+3. Running the above command gives a JupyterLab notebook URL, copy that URL and launch a browser to follow along the notebook and run each cell.
 
-**Note that you may also use launch the pyspark or scala shells after launching a terminal in JupyterLab**
+**Note that you may also launch the pyspark or scala shells after launching a terminal in JupyterLab**
 
-### Pyspark Shell
+### PySpark Shell
 
 1. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 2. Run a container from the built image with a bash entrypoint
@@ -184,17 +194,17 @@ total 12
 4. Run some basic commands in the shell
 
    ```python
-   # Create Spark DataFrame
+   # Create a Spark DataFrame
    data = spark.range(0, 5)
 
-   # Write Delta table
+   # Write to a Delta table
    (data
       .write
       .format("delta")
       .save("/tmp/delta-table")
    )
 
-   # Read Delta table
+   # Read from the Delta table
    df = (spark
            .read
            .format("delta")
@@ -202,13 +212,13 @@ total 12
            .orderBy("id")
          )
 
-   # Show Delta table
+   # Show the Delta table
    df.show()
    ```
 
 5. Continue with the quickstart [here](https://docs.delta.io/latest/quick-start.html#create-a-table&language-python)
 
-6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in /tmp/delta-table. Once you close your pyspark process, run a list command in your Docker shell and you should get something similar to below.
+6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in `/tmp/delta-table`. Once you close your `pyspark` process, run a list command in your Docker shell and you should get something similar to below.
 
 <details><summary>Click to view output</summary>
 
@@ -225,6 +235,7 @@ total 36
 4 -rw-r--r-- 1 NBuser  486 Apr 13 06:01 part-00003-909fee02-574a-47ba-9a3b-d531eec7f0d7-c000.snappy.parquet
 4 -rw-r--r-- 1 NBuser   12 Apr 13 06:01 .part-00003-909fee02-574a-47ba-9a3b-d531eec7f0d7-c000.snappy.parquet.crc
 ```
+
 </details>
 
 ### Scala Shell
@@ -247,17 +258,17 @@ total 36
 4. Run some basic commands in the shell
 
    ```scala
-   // Create Spark DataFrame
+   // Create a Spark DataFrame
    val data = spark.range(0, 5)
 
-   // Write Delta table
+   // Write to a Delta table
    (data
       .write
       .format("delta")
       .save("/tmp/delta-table")
    )
 
-   // Read Delta table
+   // Read from the Delta table
    val df = (spark
                .read
                .format("delta")
@@ -265,16 +276,15 @@ total 36
                .orderBy("id")
             )
 
-   // Show Delta table
+   // Show the Delta table
    df.show()
    ```
 
 5. Follow the quickstart [here](https://docs.delta.io/latest/quick-start.html#create-a-table&language-scala)
 
-6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in /tmp/delta-table. Once you close your pyspark process, run a list command in your Docker shell and you should get something similar to below.
+6. To verify that you have a Delta table, you can list the contents within the folder of your Delta table. For example, in the previous code, you saved the table in `/tmp/delta-table`. Once you close your Scala Spark process [`spark-shell`], run a list command in your Docker shell and you should get something similar to below.
 
 <details><summary>Click to view output</summary>
-
 
 ```bash
 $ ls -lsgA /tmp/delta-table
@@ -289,9 +299,11 @@ total 36
 4 -rw-r--r-- 1 NBuser  486 Apr 13 06:04 part-00003-5655406d-cc0b-41bb-80ed-b1dec3117bad-c000.snappy.parquet
 4 -rw-r--r-- 1 NBuser   12 Apr 13 06:04 .part-00003-5655406d-cc0b-41bb-80ed-b1dec3117bad-c000.snappy.parquet.crc
 ```
+
 </details>
 
 ### Delta Rust API
+
 1. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 
 2. Run a container from the built image with a bash entrypoint
@@ -324,13 +336,13 @@ DeltaTable(../quickstart_docker/rs/data/COVID-19_NYT)
 
 === Delta table files ===
 [
-   Path { raw: "part-00000-a496f40c-e091-413a-85f9-b1b69d4b3b4e-c000.snappy.parquet" }, 
-   Path { raw: "part-00001-9d9d980b-c500-4f0b-bb96-771a515fbccc-c000.snappy.parquet" }, 
-   Path { raw: "part-00002-8826af84-73bd-49a6-a4b9-e39ffed9c15a-c000.snappy.parquet" }, 
-   Path { raw: "part-00003-539aff30-2349-4b0d-9726-c18630c6ad90-c000.snappy.parquet" }, 
-   Path { raw: "part-00004-1bb9c3e3-c5b0-4d60-8420-23261f58a5eb-c000.snappy.parquet" }, 
-   Path { raw: "part-00005-4d47f8ff-94db-4d32-806c-781a1cf123d2-c000.snappy.parquet" }, 
-   Path { raw: "part-00006-d0ec7722-b30c-4e1c-92cd-b4fe8d3bb954-c000.snappy.parquet" }, 
+   Path { raw: "part-00000-a496f40c-e091-413a-85f9-b1b69d4b3b4e-c000.snappy.parquet" },
+   Path { raw: "part-00001-9d9d980b-c500-4f0b-bb96-771a515fbccc-c000.snappy.parquet" },
+   Path { raw: "part-00002-8826af84-73bd-49a6-a4b9-e39ffed9c15a-c000.snappy.parquet" },
+   Path { raw: "part-00003-539aff30-2349-4b0d-9726-c18630c6ad90-c000.snappy.parquet" },
+   Path { raw: "part-00004-1bb9c3e3-c5b0-4d60-8420-23261f58a5eb-c000.snappy.parquet" },
+   Path { raw: "part-00005-4d47f8ff-94db-4d32-806c-781a1cf123d2-c000.snappy.parquet" },
+   Path { raw: "part-00006-d0ec7722-b30c-4e1c-92cd-b4fe8d3bb954-c000.snappy.parquet" },
    Path { raw: "part-00007-4582392f-9fc2-41b0-ba97-a74b3afc8239-c000.snappy.parquet" }
 ]
 ```
@@ -338,8 +350,8 @@ DeltaTable(../quickstart_docker/rs/data/COVID-19_NYT)
 </p>
 </details>
 
-
 4. Execute `examples/read_delta_datafusion.rs` to query the `covid19_nyt` Delta table using `datafusion`
+
 ```bash
 cargo run --example read_delta_datafusion
 ```
@@ -351,14 +363,14 @@ cargo run --example read_delta_datafusion
 cargo run --example read_delta_datafusion
 
 [
-   RecordBatch { 
-      schema: Schema { 
+   RecordBatch {
+      schema: Schema {
          fields: [
-            Field { name: "cases", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, 
-            Field { name: "county", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }, 
+            Field { name: "cases", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None },
+            Field { name: "county", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None },
             Field { name: "date", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: None }
-         ], metadata: {} 
-      }, 
+         ], metadata: {}
+      },
       columns: [PrimitiveArray<Int32>
       [
       1,
@@ -380,8 +392,8 @@ cargo run --example read_delta_datafusion
       "2020-01-23",
       "2020-01-24",
       "2020-01-24",
-      ]], 
-      row_count: 5 
+      ]],
+      row_count: 5
    }
 ]
 ```
@@ -390,9 +402,10 @@ cargo run --example read_delta_datafusion
 </details>
 
 ### [Optional] ROAPI
-You can query your Delta Lake table with [Apache Arrow](https://github.com/apache/arrow) and [Datafusion](https://github.com/apache/arrow-datafusion) using [ROAPI](https://roapi.github.io/docs/config/dataset-formats/delta.html) which is pre-installed in this docker.
 
-> Note: If you need to do this in your environment, run the command `pip3 install roapi==0.8.1`
+You can query your Delta Lake table with [Apache Arrow](https://github.com/apache/arrow) and [Datafusion](https://github.com/apache/arrow-datafusion) using [ROAPI](https://roapi.github.io/docs/config/dataset-formats/delta.html) which are pre-installed in this docker.
+
+> Note: If you need to do this in your own environment, run the command `pip3 install roapi==0.8.1`
 
 1. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 
@@ -401,21 +414,24 @@ You can query your Delta Lake table with [Apache Arrow](https://github.com/apach
    ```bash
    docker run --name delta_quickstart --rm -it -p 8080:8080 --entrypoint bash delta_quickstart
    ```
-3. Start the `roapi` API using the following command.  Notes: 
 
-   + the API calls are pushed to the `nohup.out` file.
-   + if you haven't created the `deltars_table` in your container create it via the [delta-rs Python](#delta-rs-python) option above.  Alternatively you may omit the following from the command:
-   `--table 'deltars_table=/tmp/deltars_table/,format=delta'` as well as any steps that call the `deltars_table`
+3. Start the `roapi` API using the following command. Notes:
 
+   - the API calls are pushed to the `nohup.out` file.
+   - if you haven't created the `deltars_table` in your container create it via the [delta-rs Python](#delta-rs-python) option above. Alternatively you may omit the following from the command:
+     `--table 'deltars_table=/tmp/deltars_table/,format=delta'` as well as any steps that call the `deltars_table`
 
    ```bash
    nohup roapi --addr-http 0.0.0.0:8080 --table 'deltars_table=/tmp/deltars_table/,format=delta' --table 'covid19_nyt=/opt/spark/work-dir/rs/data/COVID-19_NYT,format=delta' &
    ```
 
-4. Open another shell to connect to the same Docker image.
+4. Open another shell to connect to the same Docker image
+
    ```bash
    docker exec -it delta_quickstart /bin/bash
    ```
+
+> Note: Run the below steps in the shell launched in the previous step
 
 5. Check the schema of the two Delta tables
    ```bash
@@ -448,8 +464,8 @@ curl -X POST -d "SELECT * FROM deltars_table"  localhost:8080/api/sql
 
 [{"0":0},{"0":1},{"0":2},{"0":3},{"0":4},{"0":6},{"0":7},{"0":8},{"0":9},{"0":10}]
 ```
-</details>
 
+</details>
 
 6. Query the `covid19_nyt` table
    ```bash

--- a/static/quickstart_docker/README.md
+++ b/static/quickstart_docker/README.md
@@ -7,6 +7,8 @@ Follow the steps below to build an Apache Spark<sup>TM</sup> image with Delta La
 1. [Build the image](#Build-the-Image)
 2. [Choose an interface](#Choose-an-Interface)
 
+> Note: Python version available in this Docker image is 3.8.10 and is available as `python3`.
+
 ## Build the Image
 
 1. Clone this repo
@@ -51,7 +53,7 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
    python3
    ```
 
-   > Note, the Delta Rust Python bindings are already installed in this docker. To do this manually in your own environment, you can install `pip3 install deltalake`
+   > Note: The Delta Rust Python bindings are already installed in this docker. To do this manually in your own environment, you can install `pip3 install deltalake==0.6.4`
 
 4. Run some basic commands in the shell
 
@@ -121,8 +123,7 @@ The current version is `delta-core_2.12:2.1.0` which corresponds to Apache Spark
 
   # Show table
   dt.to_pandas()
-  ```
-  ```python  
+
   ## Output
       0
    0  0
@@ -391,7 +392,7 @@ cargo run --example read_delta_datafusion
 ### [Optional] ROAPI
 You can query your Delta Lake table with [Apache Arrow](https://github.com/apache/arrow) and [Datafusion](https://github.com/apache/arrow-datafusion) using [ROAPI](https://roapi.github.io/docs/config/dataset-formats/delta.html) which is pre-installed in this docker.
 
-> Note, If you need to do this in your environment, run the command `pip3 install roapi`
+> Note: If you need to do this in your environment, run the command `pip3 install roapi==0.8.1`
 
 1. Open a bash shell (if on windows use git bash, WSL, or any shell configured for bash commands)
 

--- a/static/quickstart_docker/quickstart.ipynb
+++ b/static/quickstart_docker/quickstart.ipynb
@@ -3,12 +3,17 @@
   {
    "cell_type": "markdown",
    "id": "79f6bcb2-baac-49aa-ba3b-f3bac4e0f9f5",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "# Delta Lake Pyspark Quickstart\n",
+    "# Delta Lake PySpark Quickstart\n",
     "\n",
-    "Referring to https://docs.delta.io/latest/quick-start.html, the following steps have been taken care of by the docker image\n",
+    "Referring to https://docs.delta.io/latest/quick-start.html, the following steps have been taken care of by the docker image.\n",
     "\n",
+    "> Note: You do **NOT** need to run these 2 commands.\n",
+    "\n",
+    "## Python Notes\n",
     "```bash\n",
     "pip install pyspark==<compatible-spark-version>\n",
     "\n",
@@ -24,14 +29,51 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e27326eb-b153-455b-aac7-e1fef5b265c6",
+   "metadata": {},
+   "source": [
+    "## Write to and read from a Delta Lake table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d303e34b-0ebf-4f24-b1cb-be39cea040b9",
+   "metadata": {},
+   "source": [
+    "### Write a Spark DataFrame to a Delta Lake table"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "df98ff82-9a19-4744-94ca-0d1e2050c7e4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
    "source": [
     "data = spark.range(0, 5)\n",
-    "data.write.format(\"delta\").save(\"/tmp/delta-table\")"
+    "\n",
+    "(data\n",
+    "  .write\n",
+    "  .format(\"delta\")\n",
+    "  .save(\"/tmp/delta-table\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8aae7e09-295c-4032-b4b5-8fca0f90f334",
+   "metadata": {},
+   "source": [
+    "### Read the above Delta Lake table to a Spark DataFrame and display the DataFrame"
    ]
   },
   {
@@ -47,19 +89,41 @@
       "+---+\n",
       "| id|\n",
       "+---+\n",
+      "|  0|\n",
+      "|  1|\n",
       "|  2|\n",
       "|  3|\n",
-      "|  0|\n",
       "|  4|\n",
-      "|  1|\n",
       "+---+\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "df = spark.read.format(\"delta\").load(\"/tmp/delta-table\")\n",
+    "df = (spark\n",
+    "        .read\n",
+    "        .format(\"delta\")\n",
+    "        .load(\"/tmp/delta-table\")\n",
+    "        .orderBy(\"id\")\n",
+    "      )\n",
+    "\n",
     "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64c3a41b-b2bf-4754-b3d9-998fb00379db",
+   "metadata": {},
+   "source": [
+    "## Overwrite a Delta Lake table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a1104e6-98e8-4401-b7c7-007de71b6f91",
+   "metadata": {},
+   "source": [
+    "### Overwrite the Delta Lake table written in the above step"
    ]
   },
   {
@@ -67,10 +131,32 @@
    "execution_count": 3,
    "id": "91c5e69b-f615-4fd8-97c0-c4e1739740fc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
    "source": [
     "data = spark.range(5, 10)\n",
-    "data.write.format(\"delta\").mode(\"overwrite\").save(\"/tmp/delta-table\")"
+    "\n",
+    "(data\n",
+    "  .write\n",
+    "  .format(\"delta\")\n",
+    "  .mode(\"overwrite\")\n",
+    "  .save(\"/tmp/delta-table\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11e5297c-f6b4-41e0-8014-54d6958ea352",
+   "metadata": {},
+   "source": [
+    "### Read the above overwritten Delta Lake table to a Spark DataFrame and display the DataFrame"
    ]
   },
   {
@@ -87,26 +173,91 @@
       "| id|\n",
       "+---+\n",
       "|  5|\n",
-      "|  7|\n",
-      "|  9|\n",
-      "|  8|\n",
       "|  6|\n",
+      "|  7|\n",
+      "|  8|\n",
+      "|  9|\n",
       "+---+\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "df = spark.read.format(\"delta\").load(\"/tmp/delta-table\")\n",
+    "df = (spark\n",
+    "        .read\n",
+    "        .format(\"delta\")\n",
+    "        .load(\"/tmp/delta-table\")\n",
+    "        .orderBy(\"id\")\n",
+    "      )\n",
+    "\n",
     "df.show()"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ed33f55e-cfa2-4a09-a95d-0238b8f5d9e0",
+   "metadata": {},
+   "source": [
+    "## Showcase `update`, `delete` and `merge` features of Delta Lake and display the corresponding DataFrames"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "a1fec5f6-1aaa-4bc3-a2fa-b357e6bb6c98",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+\n",
+      "| id|\n",
+      "+---+\n",
+      "|  5|\n",
+      "|  7|\n",
+      "|  9|\n",
+      "|106|\n",
+      "|108|\n",
+      "+---+\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+\n",
+      "| id|\n",
+      "+---+\n",
+      "|  5|\n",
+      "|  7|\n",
+      "|  9|\n",
+      "+---+\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -143,35 +294,121 @@
     "from delta.tables import *\n",
     "from pyspark.sql.functions import *\n",
     "\n",
-    "deltaTable = DeltaTable.forPath(spark, \"/tmp/delta-table\")\n",
+    "delta_table = DeltaTable.forPath(spark, \"/tmp/delta-table\")\n",
     "\n",
     "# Update every even value by adding 100 to it\n",
-    "deltaTable.update(\n",
-    "  condition = expr(\"id % 2 == 0\"),\n",
-    "  set = { \"id\": expr(\"id + 100\") })\n",
+    "(delta_table\n",
+    "  .update(\n",
+    "    condition = expr(\"id % 2 == 0\"),\n",
+    "    set = { \"id\": expr(\"id + 100\") }\n",
+    "  )\n",
+    ")\n",
+    "(delta_table\n",
+    "  .toDF()\n",
+    "  .orderBy(\"id\")\n",
+    "  .show()\n",
+    ")\n",
     "\n",
     "# Delete every even value\n",
-    "deltaTable.delete(condition = expr(\"id % 2 == 0\"))\n",
+    "(delta_table\n",
+    "  .delete(\n",
+    "    condition = expr(\"id % 2 == 0\")\n",
+    "  )\n",
+    ")\n",
+    "\n",
+    "(delta_table\n",
+    "  .toDF()\n",
+    "  .orderBy(\"id\")\n",
+    "  .show()\n",
+    ")\n",
     "\n",
     "# Upsert (merge) new data\n",
-    "newData = spark.range(0, 20)\n",
+    "new_data = spark.range(0, 20)\n",
     "\n",
-    "deltaTable.alias(\"oldData\") \\\n",
+    "(delta_table.alias(\"old_data\")\n",
     "  .merge(\n",
-    "    newData.alias(\"newData\"),\n",
-    "    \"oldData.id = newData.id\") \\\n",
-    "  .whenMatchedUpdate(set = { \"id\": col(\"newData.id\") }) \\\n",
-    "  .whenNotMatchedInsert(values = { \"id\": col(\"newData.id\") }) \\\n",
+    "      new_data.alias(\"new_data\"),\n",
+    "      \"old_data.id = new_data.id\"\n",
+    "      )\n",
+    "  .whenMatchedUpdate(set = { \"id\": col(\"new_data.id\") })\n",
+    "  .whenNotMatchedInsert(values = { \"id\": col(\"new_data.id\") })\n",
     "  .execute()\n",
+    ")\n",
     "\n",
-    "deltaTable.toDF().show()"
+    "(delta_table\n",
+    "  .toDF()\n",
+    "  .orderBy(\"id\")\n",
+    "  .show()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b1e437d-93ab-4ced-839a-0f01bf568817",
+   "metadata": {},
+   "source": [
+    "## Time travel feature of Delta Lake"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d40cfbc6-fc4a-4f1f-9b2b-790d7170ba5c",
+   "metadata": {},
+   "source": [
+    "### Find the entire history of the above Delta Lake table"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "dbb43006-112b-4841-80fd-6179c802d8ec",
+   "id": "0c488aac-6eab-40cc-ae66-fb50b6e79e6f",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-------+--------------------+---------+--------------------+--------------------+--------------------+\n",
+      "|version|           timestamp|operation| operationParameters|    operationMetrics|          engineInfo|\n",
+      "+-------+--------------------+---------+--------------------+--------------------+--------------------+\n",
+      "|      4|2023-04-13 06:11:...|    MERGE|{predicate -> (ol...|{numTargetRowsCop...|Apache-Spark/3.3....|\n",
+      "|      3|2023-04-13 06:11:...|   DELETE|{predicate -> [\"(...|{numRemovedFiles ...|Apache-Spark/3.3....|\n",
+      "|      2|2023-04-13 06:11:...|   UPDATE|{predicate -> ((i...|{numRemovedFiles ...|Apache-Spark/3.3....|\n",
+      "|      1|2023-04-13 06:11:...|    WRITE|{mode -> Overwrit...|{numFiles -> 4, n...|Apache-Spark/3.3....|\n",
+      "|      0|2023-04-13 06:11:...|    WRITE|{mode -> ErrorIfE...|{numFiles -> 4, n...|Apache-Spark/3.3....|\n",
+      "+-------+--------------------+---------+--------------------+--------------------+--------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get the full history of the table\n",
+    "delta_table_history = (DeltaTable\n",
+    "                        .forPath(spark, \"/tmp/delta-table\")\n",
+    "                        .history()\n",
+    "                      )\n",
+    "\n",
+    "(delta_table_history\n",
+    "   .select(\"version\", \"timestamp\", \"operation\", \"operationParameters\", \"operationMetrics\", \"engineInfo\")\n",
+    "   .show()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4aa63ae4-11d0-4aef-9bdb-58fa76c1fd54",
+   "metadata": {},
+   "source": [
+    "### Latest version of the Delta Lake table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8cbfda73-d20a-4104-9178-040e079a92dc",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -180,48 +417,171 @@
       "+---+\n",
       "| id|\n",
       "+---+\n",
+      "|  0|\n",
+      "|  1|\n",
       "|  2|\n",
       "|  3|\n",
-      "|  0|\n",
       "|  4|\n",
-      "|  1|\n",
+      "|  5|\n",
+      "|  6|\n",
+      "|  7|\n",
+      "|  8|\n",
+      "|  9|\n",
+      "| 10|\n",
+      "| 11|\n",
+      "| 12|\n",
+      "| 13|\n",
+      "| 14|\n",
+      "| 15|\n",
+      "| 16|\n",
+      "| 17|\n",
+      "| 18|\n",
+      "| 19|\n",
       "+---+\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "df = spark.read.format(\"delta\").option(\"versionAsOf\", 0).load(\"/tmp/delta-table\")\n",
+    "df = (spark\n",
+    "        .read\n",
+    "        .format(\"delta\")\n",
+    "        .load(\"/tmp/delta-table\")\n",
+    "        .orderBy(\"id\")\n",
+    "      )\n",
+    "\n",
     "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e7cce27-2852-4fc8-b61c-747023f90658",
+   "metadata": {},
+   "source": [
+    "### Time travel to the version `0` of the Delta Lake table using Delta Lake's history feature"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e0840907-f972-43de-9233-59076f32acc7",
+   "id": "dbb43006-112b-4841-80fd-6179c802d8ec",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+\n",
+      "| id|\n",
+      "+---+\n",
+      "|  0|\n",
+      "|  1|\n",
+      "|  2|\n",
+      "|  3|\n",
+      "|  4|\n",
+      "+---+\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "streamingDf = spark.readStream.format(\"rate\").load()\n",
-    "stream = streamingDf.selectExpr(\"value as id\").writeStream.format(\"delta\").option(\"checkpointLocation\", \"/tmp/checkpoint\").start(\"/tmp/delta-table\")"
+    "df = (spark\n",
+    "        .read\n",
+    "        .format(\"delta\")\n",
+    "        .option(\"versionAsOf\", 0)\n",
+    "        .load(\"/tmp/delta-table\")\n",
+    "        .orderBy(\"id\")\n",
+    "      )\n",
+    "\n",
+    "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d77368f4-2d51-493b-8c48-362b0ceedc38",
+   "metadata": {},
+   "source": [
+    "### Time travel to the version `3` of the Delta Lake table using Delta Lake's  history feature"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
+   "id": "9daa8958-237b-4be2-b397-759ea9686b63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = (spark\n",
+    "        .read\n",
+    "        .format(\"delta\")\n",
+    "        .option(\"versionAsOf\", 3)\n",
+    "        .load(\"/tmp/delta-table\")\n",
+    "        .orderBy(\"id\")\n",
+    "      )\n",
+    "\n",
+    "df.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd078e9b-9682-4027-aa63-96ae1c32b2eb",
+   "metadata": {},
+   "source": [
+    "## A little bit of Streaming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0840907-f972-43de-9233-59076f32acc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "streaming_df = (spark\n",
+    "                 .readStream\n",
+    "                 .format(\"rate\")\n",
+    "                 .load()\n",
+    "               )\n",
+    "\n",
+    "stream = (streaming_df\n",
+    "            .selectExpr(\"value as id\")\n",
+    "            .writeStream\n",
+    "            .format(\"delta\")\n",
+    "            .option(\"checkpointLocation\", \"/tmp/checkpoint\")\n",
+    "            .start(\"/tmp/delta-table\")\n",
+    "          )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "769b4446-11f8-4948-9f76-cd709ba65bd5",
    "metadata": {},
    "outputs": [],
    "source": [
     "# To view the results of this step, view your container logs after execution using: docker logs --follow <first 4 number of container id>\n",
     "\n",
-    "stream2 = spark.readStream.format(\"delta\").load(\"/tmp/delta-table\").writeStream.format(\"console\").start()"
+    "stream2 = (spark\n",
+    "            .readStream\n",
+    "            .format(\"delta\")\n",
+    "            .load(\"/tmp/delta-table\")\n",
+    "            .writeStream\n",
+    "            .format(\"console\")\n",
+    "            .start()\n",
+    "          )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f98d7697-de24-411f-a053-298b53f948b1",
+   "id": "cd6b4be7-f540-43ca-acbe-b4ceaab19178",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -229,7 +589,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.5 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -243,7 +603,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
This PR fixes the version incompatibilities of the docker image and also updates the README file to fix all the commands. Jupyter notebook also has been updated.
All the steps and commands listed in the README run successfully with this updated version of the Docker image created specifically against Delta Lake Core v2.1.0 and Apache Spark v3.3.1