### PR TITLE
update command to run jupyterlab locally

### DIFF
--- a/static/quickstart_docker/README.md
+++ b/static/quickstart_docker/README.md
@@ -204,7 +204,7 @@ The current version is `delta-core_2.12:2.3.0` which corresponds to Apache Spark
 
    ```bash
    # Build entry point
-   docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 delta_quickstart
+   docker run --name delta_quickstart --rm -it -p 8888-8889:8888-8889 deltaio/delta-docker:latest
    ```
 
    ```bash


### PR DESCRIPTION
Changed entrypoint to fix delta_quickstart not found locally error when image was pulled from dockerhub.