### PR TITLE
add checkpoint Interval to properties table

### DIFF
--- a/src/pages/latest/table-properties.mdx
+++ b/src/pages/latest/table-properties.mdx
@@ -8,6 +8,7 @@ Delta Lake reserves Delta table properties starting with `delta`. These properti
 | Property | Description | Data Type | Default |
 |-|-|-|-|
 | `delta.appendOnly` | `true` for this Delta table to be append-only. If append-only, existing records cannot be deleted, and existing values cannot be updated. See [Table properties](/latest/delta-batch.html#-table-properties). | `Boolean` | `false`|
+|`delta.checkpointInterval` | How often to checkpoint the delta log.  See [Checkpoints protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#checkpoints)|`Int`|`10`|
 |`delta.checkpoint.writeStatsAsJson` | `true` for Delta Lake to write file statistics in checkpoints in JSON format for the stats column. | `Boolean` | `true`|
 |`delta.checkpoint.writeStatsAsStruct` | `true` for Delta Lake to write file statistics to checkpoints in struct format for the stats_parsed column and to write partition values as a struct for partitionValues_parsed. | `Boolean`| (none)|
 |`delta.compatibility.symlinkFormatManifest.enabled`|`true` for Delta Lake to configure the Delta table so that all write operations on the table automatically update the manifests.  See Step 3: [Update manifests](https://docs.delta.io/latest/presto-integration.html#-step-3-update-manifests).|`Boolean`|`false`|


### PR DESCRIPTION
https://github.com/delta-io/delta-docs/issues/41

`delta.checkpointInterval` property is missing on [properties table](https://docs.delta.io/latest/table-properties.html).

I referenced the `CHECKPOINT_INTERVAL` variable from delta github code. ⬇️ 
https://github.com/delta-io/delta/blob/12efca46ba31ce89164469c0bad110b69e291a73/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala#L390-L396